### PR TITLE
RPC results messed up after timeout

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client
             $timeout = $this->timeout;
         }
 
-        $event = new Request($name, $args);
+	$event = new Request($name, $args, uniqid(posix_getpid()));
         $this->context->hookBeforeSendRequest($event, $this);
         $this->socket->sendMulti($event->serialize());
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client
             $timeout = $this->timeout;
         }
 
-	$event = new Request($name, $args, uniqid(posix_getpid()));
+        $event = new Request($name, $args, uniqid(posix_getpid()));
         $this->context->hookBeforeSendRequest($event, $this);
         $this->socket->sendMulti($event->serialize());
 


### PR DESCRIPTION
## Summary of changes

In source file, Client.php
modify
$event = new Request($name, $args)
to
$event = new Request($name, $args, uniqid(posix_getpid()));

## How to Test
1) download test-rpc.php / php-stress_testing.py from ticket
2) make some change to adapt your local env.
3) run : python php-stress_testing.py

/fyi: @tjoelsson , @mark-juwai : Please review && thank you all.