### PR TITLE
Reconnect the socket when timeout

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -71,6 +71,11 @@ class Client
 
     public function __call($name, $args)
     {
+        $connectedEndpoints = $this->socket->getEndpoints();
+        if (empty($connectedEndpoints['connect'])) {
+            $this->connect();
+        }
+
         $response  = $this->sync($name, $args);
         return $response;   
     }
@@ -81,11 +86,10 @@ class Client
         $this->socket->connect($endpoint);
     }
 
-    public function reconnect()
+    public function disconnect()
     {
         $endpoint = $this->context->hookResolveEndpoint($this->_endpoint, $this->_version);
         $this->socket->disconnect($endpoint);
-        $this->socket->connect($endpoint);
     }
 
     public function setTimeout($timeout)
@@ -114,8 +118,8 @@ class Client
             $this->context->hookAfterResponse($event, $this);
             return $event->getContent(); 
         } else {
-            // Reconnect the socket when timeout to avoid messages been messed up.
-            $this->reconnect();
+            // Disconnect the socket when timeout to avoid messages been messed up.
+            $this->disconnect();
             throw new TimeoutException('Timout after ' . $this->timeout .' ms');
         }
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -81,6 +81,13 @@ class Client
         $this->socket->connect($endpoint);
     }
 
+    public function reconnect()
+    {
+        $endpoint = $this->context->hookResolveEndpoint($this->_endpoint, $this->_version);
+        $this->socket->disconnect($endpoint);
+        $this->socket->connect($endpoint);
+    }
+
     public function setTimeout($timeout)
     {
         $this->timeout = $timeout;
@@ -107,6 +114,8 @@ class Client
             $this->context->hookAfterResponse($event, $this);
             return $event->getContent(); 
         } else {
+            // Reconnect the socket when timeout to avoid messages been messed up.
+            $this->reconnect();
             throw new TimeoutException('Timout after ' . $this->timeout .' ms');
         }
     }


### PR DESCRIPTION
Reconnect the socket when request timeouts, otherwise the afterward messages will be mixed up.


It is caused by:
1. When first request times out, the client raises timeout exception without any extra handles.
2. The socket is still connecting, and the first request finished, then the result stays in the queue waiting to be retrieved.
2. When the second request comes and doesn't timeout, it retrieves the first message on the top of the queue (result of first request). And the result for the second request stays in the queue.
4. The third request gets the result of second request...